### PR TITLE
fix: b&w icon toggle now correctly restores color icons

### DIFF
--- a/app/src/main/java/com/termux/app/SuggestionBarView.java
+++ b/app/src/main/java/com/termux/app/SuggestionBarView.java
@@ -312,7 +312,9 @@ public final class SuggestionBarView extends GridLayout {
     }
 
     public void setBandW(boolean bandW) {
+        if (this.bandW == bandW) return;
         this.bandW = bandW;
+        lastSurfaceRenderSignature = 0;
     }
 
     public void setSearchTolerance(int searchTolerance) {
@@ -1382,6 +1384,7 @@ public final class SuggestionBarView extends GridLayout {
         int signature = 17;
         signature = (31 * signature) + (azPreview ? 1 : 0);
         signature = (31 * signature) + (pinnedSurface ? 1 : 0);
+        signature = (31 * signature) + (bandW ? 1 : 0);
         signature = (31 * signature) + Math.max(1, buttonCount);
         signature = (31 * signature) + pinnedPageIndex;
         signature = (31 * signature) + activeAzPageIndex;
@@ -1486,6 +1489,8 @@ public final class SuggestionBarView extends GridLayout {
             };
             ColorFilter colorFilter = new ColorMatrixColorFilter(colorMatrix);
             imageButton.setColorFilter(colorFilter);
+        } else {
+            icon.clearColorFilter();
         }
         imageButton.setOnClickListener(v -> launchEntryFromTouch(v, entry, lastTerminalView));
         imageButton.setContentDescription(entry.label);
@@ -4335,6 +4340,8 @@ public final class SuggestionBarView extends GridLayout {
                 0, 0, 0, 1, 0
             };
             button.setColorFilter(new ColorMatrixColorFilter(colorMatrix));
+        } else {
+            icon.clearColorFilter();
         }
         button.setOnClickListener(v -> launchEntryFromTouch(v, entry, lastTerminalView));
         bindAppContextLongPress(button, entry, -1, sourceFolder, resolveForSelectionRef(entry.appRef), false);

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -622,6 +622,7 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
             mTermuxTerminalViewClient.onResume();
         maybeRecoverFromEmptySession("onResume");
 
+        applySuggestionBarPreferences();
         updateWindowBackgroundForCurrentSession();
         syncTerminalWallpaperRenderingMode();
         applySeamlessStatusBackgroundModeIfNeeded();


### PR DESCRIPTION
## Summary

- Calling `ImageView.setColorFilter()` permanently mutates the cached `Drawable` via `applyColorMod()` → `mDrawable.mutate()` → `mDrawable.setColorFilter()`. When the toggle switches back to color mode, new buttons reuse the same mutated `Drawable` from the `LruCache`, which still carries the grayscale filter.
- `ImageView.clearColorFilter()` on a freshly created button has no effect because `mHasColorFilter=false` prevents `applyColorMod()` from running.
- Fix: call `icon.clearColorFilter()` directly on the `Drawable` in the `else` branch of both `createEntryButton()` and `createPopupEntryButton()`, bypassing the `ImageView` guard entirely.
- Also include `bandW` in the render signature hash so toggling always forces a full re-render, and call `applySuggestionBarPreferences()` in `onResume()` so preference changes made while the activity was stopped (broadcast missed) are picked up when the user returns.