### PR TITLE
fix(system-monitor): CPU widget shows "--" on Android 12+ (SELinux blocks /proc/stat)

### DIFF
--- a/docs/en/examples/launcher-system-monitor
+++ b/docs/en/examples/launcher-system-monitor
@@ -33,13 +33,20 @@ refresh_cache() {
 }
 
 read_cpu_ticks() {
-    awk '/^cpu / {
-        total = 0
-        for (i = 2; i <= NF; i++) total += $i
-        idle = $5 + $6
-        print total, idle
-        exit
-    }' /proc/stat 2>/dev/null
+    # /proc/stat is unreadable by unprivileged apps on Android 12+ (SELinux denies it),
+    # which silently zeroes the CPU widget. Fall back to rish (Shizuku shell). rish spawns
+    # occasionally return empty (~1/3), so retry until we get a valid "cpu " line.
+    RISH="$HOME/.rish/rish"; [ -x "$RISH" ] || RISH="$HOME/.local/bin/rish"
+    out="$(awk '/^cpu / { t=0; for (i=2;i<=NF;i++) t+=$i; print t, $5+$6; exit }' /proc/stat 2>/dev/null)"
+    if [ -z "$out" ] && [ -x "$RISH" ]; then
+        i=0
+        while [ -z "$out" ] && [ "$i" -lt 5 ]; do
+            out="$(printf 'cat /proc/stat\n' | timeout 6 "$RISH" 2>/dev/null \
+                   | awk '/^cpu / { t=0; for (j=2;j<=NF;j++) t+=$j; print t, $5+$6; exit }')"
+            i=$((i + 1))
+        done
+    fi
+    [ -n "$out" ] && printf '%s\n' "$out"
 }
 
 calculate_cpu_percent() {


### PR DESCRIPTION
## Problem

On Android 12+, the `launcher-system-monitor` example shows `--` for CPU usage in the tmux status bar (RAM still works).

## Root cause

`read_cpu_ticks()` reads `/proc/stat` directly. On Android 12+, SELinux denies unprivileged apps read access to it:

```
$ head -1 /proc/stat
head: cannot open '/proc/stat' for reading: Permission denied
```

So `read_cpu_ticks()` returns nothing, `calculate_cpu_percent()` fails, and `cpu_segment()` falls back to `--`. (RAM survives because it comes from `launcherctl resources` / ActivityManager.) The `launcher_cpu_percent()` fallback only helps when `launcherctl resources` includes `cpuPercent`, which depends on the launcher's privileged backend being bound — so whenever it isn't, CPU is dead.

## Fix

Fall back to **rish** (the Shizuku shell the launcher already relies on), which *can* read `/proc/stat`:

```
$ printf 'cat /proc/stat\n' | rish | head -1
cpu  13994024 1837689 19127153 ...
```

The direct read is still attempted first, so behavior is unchanged on systems where it already works. rish spawns intermittently return empty (~1/3 in testing), so the read retries up to 5× until it gets a valid `cpu ` line.

## Testing

Pixel 10 Pro XL, Android 16 (SDK 37), Termux-launcher.
- **Before:** CPU `--`.
- **After:** 8/8 refreshes at the 5s status cadence returned a real percentage (`69% 48% 50% 71% 57% 53% 49% 66%`), 0 dashes. RAM unaffected.

## Note for maintainer

A cleaner long-term fix might be to have `launcherctl resources` always include `cpuPercent` (via the launcher's privileged backend), so the example needn't shell out per refresh. This PR fixes the example as-shipped — happy to adjust toward whichever approach you prefer.
