### PR TITLE
TAI: LiteRT + MNN text embeddings (end-to-end)

### DIFF
--- a/.github/workflows/build_mnn_native.yml
+++ b/.github/workflows/build_mnn_native.yml
@@ -36,10 +36,19 @@ jobs:
       - name: Apply UTF-8 stream-processor patch
         run: |
           set -euxo pipefail
-          DST="mnn/apps/Android/MnnLlmChat/app/src/main/cpp/utf8_stream_processor.hpp"
+          CPP="mnn/apps/Android/MnnLlmChat/app/src/main/cpp"
+          DST="$CPP/utf8_stream_processor.hpp"
           cp -v self/ci/mnn-patch/utf8_stream_processor.hpp "$DST"
           grep -q "0xC0) != 0x80" "$DST"   # fail fast if the patch didn't land
           echo "--- patched header ---"; cat "$DST"
+
+          # TAI embedding JNI: bind MNN Transformer::Embedding into libmnnllmapp.so so MNN-format
+          # embedding models work through MnnEmbeddingSession. Add the source and register it in CMake.
+          cp -v self/ci/mnn-patch/embedding_jni.cpp "$CPP/embedding_jni.cpp"
+          if ! grep -q "embedding_jni.cpp" "$CPP/CMakeLists.txt"; then
+            sed -i 's/        llm_mnn_jni.cpp/        llm_mnn_jni.cpp\n        embedding_jni.cpp/' "$CPP/CMakeLists.txt"
+          fi
+          grep -q "embedding_jni.cpp" "$CPP/CMakeLists.txt"   # fail fast if the source did not register
 
       - name: Setup Android NDK 27.2.12479018
         id: ndk

--- a/app/src/main/java/com/alibaba/mnnllm/android/llm/MnnEmbeddingSession.java
+++ b/app/src/main/java/com/alibaba/mnnllm/android/llm/MnnEmbeddingSession.java
@@ -1,0 +1,56 @@
+package com.alibaba.mnnllm.android.llm;
+
+import androidx.annotation.NonNull;
+
+/**
+ * VAJ Terminal / TAI addition — thin wrapper over the MNN Transformer::Embedding engine.
+ *
+ * <p>Chat models go through {@link LlmSession}; embedding models (MNN config.json packages that
+ * declare {@code text_embeddings}) go through this session. The native symbols are provided by the
+ * TAI embedding JNI ({@code ci/mnn-patch/embedding_jni.cpp}) compiled into {@code libmnnllmapp.so}.
+ * Older {@code libmnnllmapp.so} builds without those symbols raise {@link UnsatisfiedLinkError} on
+ * first use, which callers treat as "MNN embeddings unavailable in this build".
+ */
+public final class MnnEmbeddingSession {
+    private long nativePtr;
+
+    static {
+        System.loadLibrary("MNN");
+        System.loadLibrary("mnnllmapp");
+    }
+
+    public synchronized void load(@NonNull String configPath) {
+        if (nativePtr != 0L) release();
+        nativePtr = initNative(configPath);
+        if (nativePtr == 0L) throw new IllegalStateException("MNN embedding model load failed.");
+    }
+
+    public synchronized boolean isLoaded() {
+        return nativePtr != 0L;
+    }
+
+    /** Output embedding dimension of the loaded model, or 0 if unknown/unloaded. */
+    public synchronized int dim() {
+        return nativePtr == 0L ? 0 : dimNative(nativePtr);
+    }
+
+    @NonNull
+    public synchronized float[] embed(@NonNull String text) {
+        if (nativePtr == 0L) throw new IllegalStateException("MNN embedding model is not loaded.");
+        float[] vector = embedNative(nativePtr, text);
+        if (vector == null) throw new IllegalStateException("MNN embedding inference returned no vector.");
+        return vector;
+    }
+
+    public synchronized void release() {
+        if (nativePtr != 0L) {
+            releaseNative(nativePtr);
+            nativePtr = 0L;
+        }
+    }
+
+    private native long initNative(String configPath);
+    private native int dimNative(long ptr);
+    private native float[] embedNative(long ptr, String text);
+    private native void releaseNative(long ptr);
+}

--- a/app/src/main/java/com/termux/ai/MnnEmbeddingRuntime.java
+++ b/app/src/main/java/com/termux/ai/MnnEmbeddingRuntime.java
@@ -1,0 +1,133 @@
+package com.termux.ai;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.alibaba.mnnllm.android.llm.MnnEmbeddingSession;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Text embeddings for MNN-format models (config.json packages that declare {@code text_embeddings}),
+ * backed by MNN's native {@code Transformer::Embedding} engine through {@link MnnEmbeddingSession}.
+ *
+ * <p>Mirrors {@link LiteRtEmbeddingRuntime}'s response shape so {@code /v1/embeddings} and
+ * {@code /api/embed} are backend-agnostic. If the installed {@code libmnnllmapp.so} predates the TAI
+ * embedding JNI, the native call raises {@link UnsatisfiedLinkError} and this runtime reports a clear
+ * {@code mnn_embeddings_unavailable} error instead of crashing the runtime process.
+ */
+final class MnnEmbeddingRuntime implements AutoCloseable {
+    @Nullable private MnnEmbeddingSession session;
+    @Nullable private String loadedConfigPath;
+    private int outputDimensions = 0;
+
+    @NonNull
+    synchronized JSONObject embed(@NonNull TaiModelSpec spec, @NonNull List<String> inputs, int dimensions) throws JSONException {
+        if (spec.localPath == null || spec.localPath.trim().isEmpty()) {
+            return error(404, "model_file_missing", "MNN embedding model config path is missing.");
+        }
+        if (dimensions < 0) {
+            return error(400, "invalid_dimensions", "Embedding dimensions must be positive.");
+        }
+        File config = new File(spec.localPath);
+        if (!config.isFile() || !config.canRead() || !"config.json".equals(config.getName())) {
+            return error(404, "model_file_not_readable", "MNN embedding models must point to a readable config.json file.");
+        }
+        try {
+            ensureLoaded(config);
+        } catch (UnsatisfiedLinkError e) {
+            return error(501, "mnn_embeddings_unavailable",
+                "This build's MNN native library does not expose embeddings. Update to a build with MNN embedding support.");
+        } catch (Throwable t) {
+            return error(500, "embedding_inference_failed",
+                "MNN embedding model failed to load: " + (t.getMessage() == null ? t.getClass().getSimpleName() : t.getMessage()));
+        }
+        int effectiveDimensions = dimensions > 0 ? dimensions : outputDimensions;
+        if (outputDimensions > 0 && (effectiveDimensions <= 0 || effectiveDimensions > outputDimensions)) {
+            return error(400, "invalid_dimensions", "Requested embedding dimensions exceed model output dimensions.");
+        }
+        try {
+            JSONArray data = new JSONArray();
+            for (int i = 0; i < inputs.size(); i++) {
+                float[] vector = session.embed(inputs.get(i));
+                float[] shaped = shapeVector(vector, dimensions);
+                JSONObject item = new JSONObject();
+                item.put("object", "embedding");
+                item.put("index", i);
+                JSONArray json = new JSONArray();
+                for (float value : shaped) json.put((double) value);
+                item.put("embedding", json);
+                data.put(item);
+            }
+            JSONObject usage = new JSONObject();
+            usage.put("prompt_tokens", 0);
+            usage.put("total_tokens", 0);
+            JSONObject response = new JSONObject();
+            response.put("object", "list");
+            response.put("data", data);
+            response.put("model", spec.id);
+            response.put("usage", usage);
+            response.put("_backend", TaiModelSpec.BACKEND_MNN_LLM);
+            response.put("_runtime", "mnn-embedding");
+            return response;
+        } catch (Throwable t) {
+            return error(500, "embedding_inference_failed",
+                "MNN embedding inference failed: " + (t.getMessage() == null ? t.getClass().getSimpleName() : t.getMessage()));
+        }
+    }
+
+    private void ensureLoaded(@NonNull File config) {
+        String configPath = config.getAbsolutePath();
+        if (session != null && configPath.equals(loadedConfigPath) && session.isLoaded()) return;
+        close();
+        MnnEmbeddingSession created = new MnnEmbeddingSession();
+        created.load(configPath);
+        session = created;
+        loadedConfigPath = configPath;
+        outputDimensions = created.dim();
+    }
+
+    /** Optional Matryoshka-style truncation: shorten to the requested size and L2-renormalize. */
+    @NonNull
+    private float[] shapeVector(@NonNull float[] vector, int dimensions) {
+        if (dimensions <= 0 || dimensions >= vector.length) return vector;
+        float[] truncated = new float[dimensions];
+        double sumSquares = 0.0;
+        for (int i = 0; i < dimensions; i++) {
+            truncated[i] = vector[i];
+            sumSquares += (double) truncated[i] * truncated[i];
+        }
+        double norm = Math.sqrt(sumSquares);
+        if (norm > 0.0) {
+            for (int i = 0; i < dimensions; i++) truncated[i] = (float) (truncated[i] / norm);
+        }
+        return truncated;
+    }
+
+    @NonNull
+    private JSONObject error(int status, @NonNull String code, @NonNull String message) throws JSONException {
+        JSONObject error = new JSONObject();
+        error.put("message", message);
+        error.put("type", status >= 500 ? "server_error" : "invalid_request_error");
+        error.put("code", code);
+        JSONObject response = new JSONObject();
+        response.put("error", error);
+        response.put("_statusCode", status);
+        return response;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (session != null) {
+            try { session.release(); } catch (Throwable ignored) { }
+            session = null;
+        }
+        loadedConfigPath = null;
+        outputDimensions = 0;
+    }
+}

--- a/app/src/main/java/com/termux/ai/MultiBackendTaiRuntime.java
+++ b/app/src/main/java/com/termux/ai/MultiBackendTaiRuntime.java
@@ -13,12 +13,14 @@ public class MultiBackendTaiRuntime implements TaiRuntime {
     private final LiteRtTaiRuntime liteRt;
     private final MnnTaiRuntime mnn;
     private final LiteRtEmbeddingRuntime embeddings;
+    private final MnnEmbeddingRuntime mnnEmbeddings;
     private TaiRuntime activeAssistant;
 
     public MultiBackendTaiRuntime(@NonNull Context context) {
         liteRt = new LiteRtTaiRuntime(context);
         mnn = new MnnTaiRuntime(context);
         embeddings = new LiteRtEmbeddingRuntime();
+        mnnEmbeddings = new MnnEmbeddingRuntime();
         activeAssistant = liteRt;
     }
 
@@ -44,6 +46,7 @@ public class MultiBackendTaiRuntime implements TaiRuntime {
     @NonNull @Override public synchronized JSONObject unload() throws JSONException {
         JSONObject result = activeAssistant.unload();
         embeddings.close();
+        mnnEmbeddings.close();
         return result;
     }
 
@@ -86,6 +89,7 @@ public class MultiBackendTaiRuntime implements TaiRuntime {
     @NonNull
     public synchronized JSONObject embed(@NonNull TaiModelSpec model, @NonNull List<String> inputs, int dimensions) throws JSONException {
         if (isLiteRtEmbeddingFlatbuffer(model)) return embeddings.embed(model, inputs, dimensions);
+        if (isMnnEmbeddingModel(model)) return mnnEmbeddings.embed(model, inputs, dimensions);
         if (inputs.size() == 1 && dimensions <= 0) return embed(model.id, inputs.get(0));
         JSONObject error = new JSONObject();
         error.put("message", "Embeddings are not available for model '" + model.id + "'.");
@@ -116,6 +120,13 @@ public class MultiBackendTaiRuntime implements TaiRuntime {
         return TaiModelSpec.BACKEND_LITERT_LM.equals(model.backend)
             && model.capabilities.contains(TaiModelSpec.CAPABILITY_TEXT_EMBEDDINGS)
             && path.endsWith(".tflite");
+    }
+
+    private boolean isMnnEmbeddingModel(@NonNull TaiModelSpec model) {
+        String path = model.localPath == null ? "" : model.localPath.toLowerCase(java.util.Locale.ROOT);
+        return TaiModelSpec.BACKEND_MNN_LLM.equals(model.backend)
+            && model.capabilities.contains(TaiModelSpec.CAPABILITY_TEXT_EMBEDDINGS)
+            && path.endsWith("config.json");
     }
 
     private JSONObject error(String code, String message) throws JSONException {

--- a/app/src/main/java/com/termux/ai/TaiManager.java
+++ b/app/src/main/java/com/termux/ai/TaiManager.java
@@ -1814,6 +1814,13 @@ public final class TaiManager {
         }
         if (capabilities.isEmpty()) {
             String normalized = artifactHint == null ? "" : artifactHint.toLowerCase(Locale.ROOT);
+            // Strip any URL query/fragment (e.g. "...tflite?download=true") before matching the extension,
+            // otherwise a downloaded embedding model is misclassified as a chat model and never gets its
+            // SentencePiece tokenizer sidecar.
+            int cut = normalized.indexOf('?');
+            if (cut >= 0) normalized = normalized.substring(0, cut);
+            cut = normalized.indexOf('#');
+            if (cut >= 0) normalized = normalized.substring(0, cut);
             if (normalized.endsWith(".tflite")) {
                 capabilities.add(TaiModelSpec.CAPABILITY_TEXT_EMBEDDINGS);
             } else {

--- a/app/src/main/java/com/termux/ai/TaiModelCatalog.java
+++ b/app/src/main/java/com/termux/ai/TaiModelCatalog.java
@@ -152,6 +152,15 @@ public final class TaiModelCatalog {
             "Mobile actions tool-call model", "litert-community/functiongemma-270m-ft-mobile-actions", "38942192c9b723af836d489074823ff33d4a3e7a",
             "mobile_actions_q8_ekv1024.litertlm", "Gemma Terms of Use", 288_964_608L, "0.3 GB", "6GB+", true,
             tags("Tools"), setOf("text_chat", "tool_use", "mobile_actions")));
+        // EmbeddingGemma is a raw .tflite served by LiteRtEmbeddingRuntime, not a chat .litertlm package.
+        // The text_embeddings capability + .tflite artifact make the downloader fetch the sentencepiece.model
+        // sidecar and route requests to the embedding runtime rather than the LiteRT-LM chat engine.
+        entries.put("embeddinggemma-300m", liteRtAvailable(
+            "embeddinggemma-300m", "EmbeddingGemma 300M", "embedding", "embedding_default", false,
+            "Text embeddings", "litert-community/embeddinggemma-300m", "870cbe05ef460385363c6b574c851ae5d8989ce3",
+            "embeddinggemma-300M_seq1024_mixed-precision.tflite", "Gemma Terms of Use", 183_329_528L, "183 MB", "4GB+", true,
+            "gemma", null, null,
+            tags("Embeddings"), setOf(TaiModelSpec.CAPABILITY_TEXT_EMBEDDINGS)));
 
         entries.put("qwen2.5-coder-1.5b-instruct-mnn", mnnAvailable(
             "qwen2.5-coder-1.5b-instruct-mnn", "Qwen2.5-Coder 1.5B", "coding", "recommended_coder", true,

--- a/app/src/main/java/com/termux/ai/TaiModelCatalog.java
+++ b/app/src/main/java/com/termux/ai/TaiModelCatalog.java
@@ -161,6 +161,12 @@ public final class TaiModelCatalog {
             "embeddinggemma-300M_seq1024_mixed-precision.tflite", "Gemma Terms of Use", 183_329_528L, "183 MB", "4GB+", true,
             "gemma", null, null,
             tags("Embeddings"), setOf(TaiModelSpec.CAPABILITY_TEXT_EMBEDDINGS)));
+        // MNN-format embedding model — routes to MnnEmbeddingRuntime via the MNN Transformer::Embedding
+        // engine. config.json + text_embeddings capability make it an embedding package, not a chat model.
+        entries.put("qwen3-embedding-0.6b-mnn", mnnAvailable(
+            "qwen3-embedding-0.6b-mnn", "Qwen3 Embedding 0.6B", "embedding", "embedding_mnn", false,
+            "Text embeddings (MNN)", "taobao-mnn/Qwen3-Embedding-0.6B-MNN", 377_998_519L,
+            "378 MB", "4GB+", "qwen3", "int4", tags("Embeddings"), setOf(TaiModelSpec.CAPABILITY_TEXT_EMBEDDINGS)));
 
         entries.put("qwen2.5-coder-1.5b-instruct-mnn", mnnAvailable(
             "qwen2.5-coder-1.5b-instruct-mnn", "Qwen2.5-Coder 1.5B", "coding", "recommended_coder", true,

--- a/app/src/main/java/com/termux/ai/TaiModelDownloader.java
+++ b/app/src/main/java/com/termux/ai/TaiModelDownloader.java
@@ -31,8 +31,14 @@ public final class TaiModelDownloader {
         "tokenizer.mtok",
         "tokenizer.txt"
     };
-    private static final String[] LITERT_EMBEDDING_SIDECARS = new String[] {
-        "sentencepiece.model"
+    // The embedding runtime always loads the tokenizer from a file named exactly "sentencepiece.model"
+    // next to the .tflite. Different HF repos publish that SentencePiece model under different names,
+    // so we try each candidate and persist whichever we find under the canonical local name.
+    private static final String LITERT_EMBEDDING_TOKENIZER = "sentencepiece.model";
+    private static final String[] LITERT_EMBEDDING_TOKENIZER_CANDIDATES = new String[] {
+        "sentencepiece.model",
+        "tokenizer.model",
+        "spiece.model"
     };
 
     public interface ProgressCallback {
@@ -448,9 +454,10 @@ public final class TaiModelDownloader {
     }
 
     private boolean requiresLiteRtEmbeddingTokenizer(@NonNull File output, @NonNull LinkedHashSet<String> capabilities) {
-        String lowerName = output.getName().toLowerCase(Locale.ROOT);
-        return lowerName.endsWith(".tflite")
-            && capabilities.contains(TaiModelSpec.CAPABILITY_TEXT_EMBEDDINGS);
+        // A raw .tflite artifact is only ever a LiteRT embedding model in this app (chat packages are
+        // .litertlm/.task containers), so it always needs its SentencePiece tokenizer sidecar — no matter
+        // how capabilities were declared or whether the download URL carried a ?download= query.
+        return output.getName().toLowerCase(Locale.ROOT).endsWith(".tflite");
     }
 
     private long downloadLiteRtEmbeddingSidecars(@NonNull String transferId, @NonNull String modelId,
@@ -462,21 +469,21 @@ public final class TaiModelDownloader {
         File modelDir = output.getParentFile();
         if (modelDir == null) throw new IllegalStateException("Model directory is missing.");
         long packageTotalBytes = expectedSizeBytes > 0L ? expectedSizeBytes : -1L;
-        long sidecarBytes = 0L;
-        for (String fileName : LITERT_EMBEDDING_SIDECARS) {
-            File fileOutput = new File(modelDir, fileName);
-            String fileUrl = baseUrl + encodeHuggingFacePath(fileName);
-            File filePartial = new File(fileOutput.getAbsolutePath() + ".part");
+
+        File tokenizerOutput = new File(modelDir, LITERT_EMBEDDING_TOKENIZER);
+        if (tokenizerOutput.isFile() && tokenizerOutput.length() > 0L) return 0L;
+        File tokenizerPartial = new File(tokenizerOutput.getAbsolutePath() + ".part");
+
+        for (String candidate : LITERT_EMBEDDING_TOKENIZER_CANDIDATES) {
+            String fileUrl = baseUrl + encodeHuggingFacePath(candidate);
             HttpURLConnection fileConn = open(fileUrl, authToken, 0);
             int fileStatus = fileConn.getResponseCode();
-            if (fileStatus < 200 || fileStatus >= 300) {
-                throw new IllegalStateException("LiteRT embedding package missing tokenizer sidecar: " + fileName);
-            }
+            if (fileStatus < 200 || fileStatus >= 300) continue;
             persist(withCurrentFile(transfer(transferId, modelId, url, output.getAbsolutePath(),
-                TaiModelStore.STATE_DOWNLOADING, currentBytes, packageTotalBytes, ""), fileName), callback);
+                TaiModelStore.STATE_DOWNLOADING, currentBytes, packageTotalBytes, ""), candidate), callback);
             long fileBytes = 0L;
             try (InputStream fileInput = new BufferedInputStream(fileConn.getInputStream());
-                 FileOutputStream fileOut = new FileOutputStream(filePartial)) {
+                 FileOutputStream fileOut = new FileOutputStream(tokenizerPartial)) {
                 byte[] buffer = new byte[1024 * 64];
                 int read;
                 while ((read = fileInput.read(buffer)) != -1) {
@@ -486,18 +493,22 @@ public final class TaiModelDownloader {
                     fileBytes += read;
                     if (currentBytes % (1024L * 1024L) < read) {
                         persist(withCurrentFile(transfer(transferId, modelId, url, output.getAbsolutePath(),
-                            TaiModelStore.STATE_DOWNLOADING, currentBytes, packageTotalBytes, ""), fileName), callback);
+                            TaiModelStore.STATE_DOWNLOADING, currentBytes, packageTotalBytes, ""), candidate), callback);
                     }
                 }
             }
-            if (fileBytes <= 0L) throw new IllegalStateException("Downloaded tokenizer sidecar is empty: " + fileName);
-            if (fileOutput.exists() && !fileOutput.delete()) throw new IllegalStateException("Could not replace tokenizer sidecar.");
-            if (!filePartial.renameTo(fileOutput)) throw new IllegalStateException("Could not finalize tokenizer sidecar download.");
-            sidecarBytes += fileBytes;
+            if (fileBytes <= 0L) {
+                if (tokenizerPartial.exists() && !tokenizerPartial.delete()) { /* best effort */ }
+                continue;
+            }
+            if (tokenizerOutput.exists() && !tokenizerOutput.delete()) throw new IllegalStateException("Could not replace tokenizer sidecar.");
+            if (!tokenizerPartial.renameTo(tokenizerOutput)) throw new IllegalStateException("Could not finalize tokenizer sidecar download.");
             persist(withCurrentFile(transfer(transferId, modelId, url, output.getAbsolutePath(),
-                TaiModelStore.STATE_DOWNLOADING, currentBytes, packageTotalBytes, ""), fileName), callback);
+                TaiModelStore.STATE_DOWNLOADING, currentBytes, packageTotalBytes, ""), LITERT_EMBEDDING_TOKENIZER), callback);
+            return fileBytes;
         }
-        return sidecarBytes;
+        throw new IllegalStateException("LiteRT embedding model is missing a SentencePiece tokenizer "
+            + "(looked for sentencepiece.model, tokenizer.model, spiece.model next to the .tflite).");
     }
 
     @NonNull

--- a/app/src/main/java/com/termux/ai/TaiModelDownloader.java
+++ b/app/src/main/java/com/termux/ai/TaiModelDownloader.java
@@ -662,6 +662,9 @@ public final class TaiModelDownloader {
             || lower.endsWith(".mnn.json")
             || lower.endsWith(".json")
             || lower.endsWith(".mtok")
+            // MNN embedding packages ship a quantized weight table alongside the graph, e.g.
+            // embeddings_int4.bin — pull raw .bin model data so embedding models import completely.
+            || lower.endsWith(".bin")
             || lower.startsWith("tokenizer."));
     }
 

--- a/app/src/main/java/com/termux/ai/TaiModelSpec.java
+++ b/app/src/main/java/com/termux/ai/TaiModelSpec.java
@@ -303,6 +303,12 @@ public final class TaiModelSpec {
         String normalizedId = normalizedIdentity(id);
 
         if (BACKEND_MNN_LLM.equals(backend)) {
+            // MNN embedding packages (config.json declaring text_embeddings) route to MnnEmbeddingRuntime,
+            // not the chat engine, so they expose embeddings exclusively.
+            if (source.contains(CAPABILITY_TEXT_EMBEDDINGS)) {
+                endpoint.add(CAPABILITY_TEXT_EMBEDDINGS);
+                return endpoint;
+            }
             addIfPresent(endpoint, source, CAPABILITY_TEXT_CHAT, source.isEmpty());
             // MNN VL models (Qwen-VL, SmolVLM, MiniCPM-V) take images; the runtime injects them as
             // inline <img> markup. Audio/video have no MNN runtime path, so they stay source-only.

--- a/ci/mnn-patch/embedding_jni.cpp
+++ b/ci/mnn-patch/embedding_jni.cpp
@@ -1,0 +1,100 @@
+// VAJ Terminal / TAI addition — JNI bridge for MNN text embeddings.
+//
+// Upstream MnnLlmChat only exposes the chat Llm engine over JNI. TAI needs
+// on-device embeddings from MNN-format models (config.json packages), so this
+// file exports a tiny embedding surface over MNN's Transformer::Embedding
+// engine (already built into libMNN.so via -DMNN_BUILD_LLM=true).
+//
+// Deliberately dependency-light: it returns a raw float[] and lets the Java/
+// Kotlin side (MnnEmbeddingSession -> MnnEmbeddingRuntime) shape the OpenAI /
+// Ollama JSON. Symbols bind to com.alibaba.mnnllm.android.llm.MnnEmbeddingSession.
+//
+// Copied into apps/Android/MnnLlmChat/app/src/main/cpp/ and added to the
+// libmnnllmapp.so source list by .github/workflows/build_mnn_native.yml.
+
+#include <jni.h>
+#include <android/log.h>
+#include <string>
+#include <vector>
+
+#include "llm/llm.hpp"
+#include "MNN/expr/Expr.hpp"
+
+#define TAI_EMBED_LOG_TAG "TaiMnnEmbedding"
+#define TAI_EMBED_LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAI_EMBED_LOG_TAG, __VA_ARGS__)
+
+using MNN::Transformer::Embedding;
+using MNN::Express::VARP;
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL
+Java_com_alibaba_mnnllm_android_llm_MnnEmbeddingSession_initNative(
+        JNIEnv *env, jobject /*thiz*/, jstring config_path) {
+    if (config_path == nullptr) return 0L;
+    const char *chars = env->GetStringUTFChars(config_path, nullptr);
+    if (chars == nullptr) return 0L;
+    std::string path(chars);
+    env->ReleaseStringUTFChars(config_path, chars);
+    Embedding *embedding = nullptr;
+    try {
+        embedding = Embedding::createEmbedding(path, true);
+    } catch (const std::exception &e) {
+        TAI_EMBED_LOGE("createEmbedding threw: %s", e.what());
+        embedding = nullptr;
+    } catch (...) {
+        TAI_EMBED_LOGE("createEmbedding threw an unknown error");
+        embedding = nullptr;
+    }
+    return reinterpret_cast<jlong>(embedding);
+}
+
+JNIEXPORT jint JNICALL
+Java_com_alibaba_mnnllm_android_llm_MnnEmbeddingSession_dimNative(
+        JNIEnv * /*env*/, jobject /*thiz*/, jlong ptr) {
+    auto *embedding = reinterpret_cast<Embedding *>(ptr);
+    if (embedding == nullptr) return 0;
+    return static_cast<jint>(embedding->dim());
+}
+
+JNIEXPORT jfloatArray JNICALL
+Java_com_alibaba_mnnllm_android_llm_MnnEmbeddingSession_embedNative(
+        JNIEnv *env, jobject /*thiz*/, jlong ptr, jstring text) {
+    auto *embedding = reinterpret_cast<Embedding *>(ptr);
+    if (embedding == nullptr || text == nullptr) return nullptr;
+    const char *chars = env->GetStringUTFChars(text, nullptr);
+    if (chars == nullptr) return nullptr;
+    std::string input(chars);
+    env->ReleaseStringUTFChars(text, chars);
+
+    VARP vector;
+    try {
+        vector = embedding->txt_embedding(input);
+    } catch (const std::exception &e) {
+        TAI_EMBED_LOGE("txt_embedding threw: %s", e.what());
+        return nullptr;
+    } catch (...) {
+        TAI_EMBED_LOGE("txt_embedding threw an unknown error");
+        return nullptr;
+    }
+    if (vector.get() == nullptr) return nullptr;
+    auto info = vector->getInfo();
+    if (info == nullptr) return nullptr;
+    const float *data = vector->readMap<float>();
+    if (data == nullptr) return nullptr;
+
+    jsize count = static_cast<jsize>(info->size);
+    jfloatArray result = env->NewFloatArray(count);
+    if (result == nullptr) return nullptr;
+    env->SetFloatArrayRegion(result, 0, count, data);
+    return result;
+}
+
+JNIEXPORT void JNICALL
+Java_com_alibaba_mnnllm_android_llm_MnnEmbeddingSession_releaseNative(
+        JNIEnv * /*env*/, jobject /*thiz*/, jlong ptr) {
+    auto *embedding = reinterpret_cast<Embedding *>(ptr);
+    delete embedding;
+}
+
+} // extern "C"


### PR DESCRIPTION
Makes on-device embeddings work end-to-end and adds MNN-format embedding support.

## LiteRT
- Add `embeddinggemma-300m` to the shipped catalog (downloads the `.tflite` + `sentencepiece.model` sidecar, routes to the embedding runtime).
- Always fetch the tokenizer sidecar for any `.tflite` download/import (a raw `.tflite` is only ever an embedding model here); try `sentencepiece.model` / `tokenizer.model` / `spiece.model`.
- Strip URL query/fragment before capability inference so `...tflite?download=true` is recognised.

## MNN (native)
- `ci/mnn-patch/embedding_jni.cpp`: JNI over MNN `Transformer::Embedding`, compiled into `libmnnllmapp.so` (`build_mnn_native.yml` updated).
- Rebuilt `libmnnllmapp.so` (embedding symbols added; chat native set verified identical).
- `MnnEmbeddingSession` + `MnnEmbeddingRuntime` (OpenAI/Ollama-neutral response), routed for `mnn-llm` + `text_embeddings` config.json models.
- Downloader also pulls `.bin` package data (e.g. `embeddings_int4.bin`).
- Catalog: `qwen3-embedding-0.6b-mnn`.

## Verified on-device (Nothing Phone 2)
- LiteRT embeddings (`embeddinggemma-300m`): 768-dim ✓
- MNN embeddings (`qwen3-embedding-0.6b-mnn`): 1024-dim ✓
- MNN chat regression (`qwen2.5-coder-1.5b-instruct-mnn`): ✓ no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)