### PR TITLE
fix: mask sensitive command logs and disclose file source before saving

### DIFF
--- a/app/src/main/java/com/termux/app/api/file/FileReceiverActivity.java
+++ b/app/src/main/java/com/termux/app/api/file/FileReceiverActivity.java
@@ -117,7 +117,7 @@ public class FileReceiverActivity extends AppCompatActivity {
                 File file = new File(path);
                 try {
                     FileInputStream in = new FileInputStream(file);
-                    promptNameAndSave(in, file.getName());
+                    promptNameAndSave(in, file.getName(), file.getAbsolutePath());
                 } catch (FileNotFoundException e) {
                     showErrorDialogAndQuit("Cannot open file: " + e.getMessage() + ".");
                 }
@@ -230,7 +230,19 @@ public class FileReceiverActivity extends AppCompatActivity {
     }
     
     void promptNameAndSave(final InputStream in, final String attachmentFileName) {
-        TextInputDialogUtils.textInput(this, R.string.title_file_received, attachmentFileName, R.string.action_file_received_edit, text -> {
+        promptNameAndSave(in, attachmentFileName, null);
+    }
+
+    /**
+     * @param sourcePath If non-null, shown to the user before saving. The incoming intent's data
+     *                    URI is not scoped by any content-provider grant when it uses the "file"
+     *                    scheme, so the path being read may lie outside anything the calling app
+     *                    itself has access to; surfacing it lets the user notice a suspicious source
+     *                    before approving the save.
+     */
+    void promptNameAndSave(final InputStream in, final String attachmentFileName, final String sourcePath) {
+        String message = sourcePath != null ? getString(R.string.msg_file_received_source, sourcePath) : null;
+        TextInputDialogUtils.textInput(this, R.string.title_file_received, message, attachmentFileName, R.string.action_file_received_edit, text -> {
             File outFile = saveStreamWithName(in, text);
             if (outFile == null)
                 return;

--- a/app/src/main/java/com/termux/privileged/PrivilegedBackend.java
+++ b/app/src/main/java/com/termux/privileged/PrivilegedBackend.java
@@ -112,4 +112,13 @@ public interface PrivilegedBackend {
      * Cleanup resources when backend is no longer needed
      */
     void cleanup();
+
+    /**
+     * Mask file paths and package names in a command string before it is logged.
+     */
+    static String maskSensitiveCommand(String command) {
+        if (command == null) return null;
+        return command.replaceAll("/[\\w/.-]+\\.apk", "<apk>")
+                      .replaceAll("[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)+", "<package>");
+    }
 }

--- a/app/src/main/java/com/termux/privileged/ShellBackend.java
+++ b/app/src/main/java/com/termux/privileged/ShellBackend.java
@@ -214,12 +214,12 @@ public class ShellBackend implements PrivilegedBackend {
                 return executeDirectCommand(args);
                 
             } catch (Exception e) {
-                Log.e(TAG, "Failed to execute command: " + command, e);
+                Log.e(TAG, "Failed to execute command: " + maskSensitive(command), e);
                 return "Error: " + e.getMessage();
             }
         }, PrivilegedExecutors.commands());
     }
-    
+
     @Override
     public boolean isOperationSupported(PrivilegedOperation operation) {
         // Shell backend supports most operations but with text-based limitations
@@ -360,10 +360,7 @@ public class ShellBackend implements PrivilegedBackend {
      * Mask sensitive values in command logging
      */
     private String maskSensitive(String command) {
-        if (command == null) return null;
-        // Mask file paths and package names for safe logging
-        return command.replaceAll("/[\\w/.-]+\\.apk", "<apk>")
-                      .replaceAll("[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)+", "<package>");
+        return PrivilegedBackend.maskSensitiveCommand(command);
     }
 
     private enum RootMethod {

--- a/app/src/main/java/com/termux/privileged/ShizukuBackend.java
+++ b/app/src/main/java/com/termux/privileged/ShizukuBackend.java
@@ -332,12 +332,12 @@ public class ShizukuBackend implements PrivilegedBackend {
                 return executeShizukuCommand(List.of("sh", "-c", command));
                 
             } catch (Exception e) {
-                Log.e(TAG, "Failed to execute command: " + command, e);
+                Log.e(TAG, "Failed to execute command: " + PrivilegedBackend.maskSensitiveCommand(command), e);
                 return "Error: " + e.getMessage();
             }
         }, PrivilegedExecutors.commands());
     }
-    
+
     @Override
     public boolean isOperationSupported(PrivilegedOperation operation) {
         // Shizuku backend supports most operations through UserService

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -523,6 +523,7 @@
 
     <!-- Termux File Receiver -->
     <string name="title_file_received">Save file in ~/downloads/</string>
+    <string name="msg_file_received_source">Source: %1$s</string>
     <string name="action_file_received_edit">Edit</string>
     <string name="action_file_received_open_directory">Open directory</string>
 

--- a/termux-shared/src/main/java/com/termux/shared/termux/interact/TextInputDialogUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/interact/TextInputDialogUtils.java
@@ -8,6 +8,7 @@ import android.view.KeyEvent;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import androidx.appcompat.app.AlertDialog;
 
@@ -21,6 +22,15 @@ public final class TextInputDialogUtils {
     }
 
     public static void textInput(Activity activity, int titleText, String initialText, int positiveButtonText, final TextSetListener onPositive, int neutralButtonText, final TextSetListener onNeutral, int negativeButtonText, final TextSetListener onNegative, final DialogInterface.OnDismissListener onDismiss) {
+        textInput(activity, titleText, null, initialText, positiveButtonText, onPositive, neutralButtonText, onNeutral, negativeButtonText, onNegative, onDismiss);
+    }
+
+    /**
+     * Same as {@link #textInput(Activity, int, String, int, TextSetListener, int, TextSetListener, int, TextSetListener, DialogInterface.OnDismissListener)},
+     * but with an optional message shown above the input field (e.g. to disclose the real source
+     * of a file being saved, since {@code initialText} is only ever the suggested file name).
+     */
+    public static void textInput(Activity activity, int titleText, String message, String initialText, int positiveButtonText, final TextSetListener onPositive, int neutralButtonText, final TextSetListener onNeutral, int negativeButtonText, final TextSetListener onNegative, final DialogInterface.OnDismissListener onDismiss) {
         final EditText input = new EditText(activity);
         input.setSingleLine();
         if (initialText != null) {
@@ -43,6 +53,12 @@ public final class TextInputDialogUtils {
         layout.setOrientation(LinearLayout.VERTICAL);
         layout.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
         layout.setPadding(paddingSides, paddingTop, paddingSides, paddingBottom);
+        if (message != null) {
+            TextView messageView = new TextView(activity);
+            messageView.setText(message);
+            messageView.setPadding(0, 0, 0, Math.round(8 * dipInPixels));
+            layout.addView(messageView);
+        }
         layout.addView(input);
         MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(activity).setTitle(titleText).setView(layout).setPositiveButton(positiveButtonText, (d, whichButton) -> onPositive.onTextSet(input.getText().toString()));
         if (onNeutral != null) {


### PR DESCRIPTION
Summary
- Privileged command execution (ShellBackend, ShizukuBackend) logged the raw command string on failure, bypassing the existing maskSensitive helper used everywhere else in ShellBackend. A failing command that embedded a credential could leak it to logcat. Moved the masking logic onto PrivilegedBackend as a shared static method so both backends apply it consistently.
- FileReceiverActivity opened file:// data URIs by path directly, without going through a content resolver grant. Any app could hand it a path outside its own storage access and have Termux read it and offer it for save into ~/downloads, with only the file name shown in the confirmation dialog. Added an optional message to the shared text input dialog and used it to show the full source path, so the user can see what is actually being read before approving the save.

Changes
- PrivilegedBackend.java: adds maskSensitiveCommand(String) as a shared static helper.
- ShellBackend.java: routes executeCommand failure logging through the shared helper; existing private maskSensitive now delegates to it.
- ShizukuBackend.java: routes executeCommand failure logging through the shared helper.
- TextInputDialogUtils.java: adds a backward compatible overload of textInput that accepts an optional message shown above the input field; existing callers are unaffected.
- FileReceiverActivity.java: passes the resolved absolute path as the disclosure message when handling file:// scheme intents.
- strings.xml: adds msg_file_received_source.

Test plan
- [x] ./gradlew :app:compileDebugJava :termux-shared:compileDebugJava builds clean against Android SDK 36, NDK 29, no errors, no warnings in the touched files
- [ ] Manual check: trigger "open with Termux" from another app using a file:// URI and confirm the save dialog now shows the source path
- [ ] Manual check: trigger a privileged command failure (root/Shizuku) with a credential embedded in the command and confirm logcat shows it masked