### PR TITLE
fix: keep input command docked above system IME

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -7711,13 +7711,11 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
         // The embedded keyboard is an ordinary bottom child. Root/decor inset policy already keeps
         // it above navigation bars, so a floating-dock gap must not be inserted beneath it.
         if (state.keyboardShown)
-            return mImeLiftPx;
-        // The capsule floats, so it keeps its bottom gap even when the keyboard is up — otherwise it
-        // sits flush against the keyboard. Non-capsule styles stay flush.
-        if (!isRoundedDockStyle()) {
-            return mImeLiftPx;
-        }
-        return mImeLiftPx + getDockLayout().capsuleBottomGapPx;
+            return 0;
+        // The system IME is already handled by adjustResize: terminal_root_container is resized
+        // above the keyboard. Adding mImeLiftPx here moves the accessory stack a second time.
+        // Keep only the capsule's visual gap; non-capsule docks remain flush.
+        return isRoundedDockStyle() ? getDockLayout().capsuleBottomGapPx : 0;
     }
 
     // Kept for test compatibility and to preserve existing RelativeLayout params in-place.


### PR DESCRIPTION
## Summary

- keep the Input command docked above the system IME
- avoid adding `mImeLiftPx` a second time as the accessory stack bottom margin
- preserve the capsule visual bottom gap for rounded dock styles

## Root cause

`adjustResize` already resizes `terminal_root_container` above the system IME. `resolveAccessoryStackBottomMarginPx()` also added `mImeLiftPx` to the accessory stack margin, so the dock was repositioned twice and the Input command jumped toward the top when the IME appeared.

## Validation

- built successfully with `assembleDebug`
- installed and tested on a Poco (`25053PC47G`) through ADB USB
- package tested: `com.termux.launcher.nix`
- confirmed the Input command remains at the bottom when the IME appears
- diagnostic report: `2026-08-31-relatorio-debug-ime-termux-launcher-nix.md`

The unit-test executor could not start because Gradle reported `ClassNotFoundException: worker.org.gradle.process.internal.worker.GradleWorkerMain`; no test assertion failure was reported.